### PR TITLE
feat: add mcp() hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+p6df module for AWS: CLI tools (`awscli`, `eksctl`, `aws-vault`, etc.), profile
+switching (`P6_DFZ_PROFILE_AWS`, `P6_AWS_ORG`), multi-language SDK installs
+(JS, Python, Go, Ruby, Rust), and MCP server (`@imazhar101/mcp-aws-server`).
 
 ## Contributing
 
@@ -38,11 +40,10 @@ TODO: Add a short summary of this module.
 - `p6df::modules::aws::deps()`
 - `p6df::modules::aws::external::brew()`
 - `p6df::modules::aws::home::symlink()`
-- `p6df::modules::aws::home::symlink::creds()`
 - `p6df::modules::aws::init(_module, dir)`
   - Args:
-    - _module -
-    - dir -
+    - _module
+    - dir
 - `p6df::modules::aws::langs()`
 - `p6df::modules::aws::langs::clones()`
 - `p6df::modules::aws::langs::go()`
@@ -50,10 +51,11 @@ TODO: Add a short summary of this module.
 - `p6df::modules::aws::langs::python()`
 - `p6df::modules::aws::langs::ruby()`
 - `p6df::modules::aws::langs::rust()`
+- `p6df::modules::aws::mcp()`
 - `p6df::modules::aws::profile::off()`
 - `p6df::modules::aws::profile::on(profile, [aws_org=])`
   - Args:
-    - profile -
+    - profile
     - OPTIONAL aws_org - []
 - `p6df::modules::aws::vscodes()`
 - `p6df::modules::aws::vscodes::config()`
@@ -80,7 +82,7 @@ TODO: Add a short summary of this module.
 - `p6df::modules::aws::svc::ec2::sg::id_from_tag_name()`
 - `p6df::modules::aws::svc::ec2::sg::show(security_group_id)`
   - Args:
-    - security_group_id -
+    - security_group_id
 - `p6df::modules::aws::svc::ec2::sgs::list()`
 - `p6df::modules::aws::svc::ec2::subnet::get()`
 - `p6df::modules::aws::svc::ec2::subnetids::get()`
@@ -91,10 +93,10 @@ TODO: Add a short summary of this module.
 - `p6df::modules::aws::svc::eks::cluster::find()`
 - `p6df::modules::aws::svc::eks::cluster::set(cluster_name)`
   - Args:
-    - cluster_name -
+    - cluster_name
 - `p6df::modules::aws::svc::eks::cluster::set(cluster_name)`
   - Args:
-    - cluster_name -
+    - cluster_name
 - `p6df::modules::aws::svc::eks::cluster::status()`
 
 ## Hierarchy
@@ -108,10 +110,11 @@ TODO: Add a short summary of this module.
 │       ├── ec2.sh
 │       └── eks.sh
 ├── libexec
+│   └── aws-eks-kubectl
 ├── README.md
 └── share
 
-5 directories, 5 files
+5 directories, 6 files
 ```
 
 ## Author

--- a/init.zsh
+++ b/init.zsh
@@ -379,3 +379,17 @@ p6df::modules::aws::profile::off() {
 
     p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: p6df::modules::aws::mcp()
+#
+#>
+######################################################################
+p6df::modules::aws::mcp() {
+
+  p6_js_npm_global_install "@imazhar101/mcp-aws-server"
+
+  p6_return_void
+}


### PR DESCRIPTION
## Summary

- Add `mcp()` hook: installs `@imazhar101/mcp-aws-server` for AI-driven AWS access (DynamoDB, Lambda, API Gateway, etc.) via MCP

## Test plan

- [ ] `p6df mcp` installs `@imazhar101/mcp-aws-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)