### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -71,11 +71,11 @@ EOF
 ######################################################################
 #<
 #
-# Function: p6df::modules::aws::external::brew()
+# Function: p6df::modules::aws::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::aws::external::brew() {
+p6df::modules::aws::external::brews() {
 
   # base
   p6df::core::homebrew::cmd::brew tap aws/tap


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly