### PR TITLE
fix(prompt): remove unnecessary quoting and fix prefix spacing in prompt context

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -321,7 +321,7 @@ p6df::modules::aws::profiles::list() {
 p6df::modules::aws::prompt::context() {
 
   local str
-  local prefix="$(p6_string_space_pad "AWS:" 16)"
+  local prefix=$(p6_string_space_pad "AWS:" 16)
   local active=$(p6_aws_cfg_prompt_info "_active")
   local source=$(p6_aws_cfg_prompt_info "_source")
   local saved=$(p6_aws_cfg_prompt_info "_saved")
@@ -330,7 +330,7 @@ p6df::modules::aws::prompt::context() {
   local item
   for item in "$active" "$source" "$saved"; do
     if p6_string_blank_NOT "$item"; then
-      str=$(p6_string_append "$str" "$prefix $item" "$P6_NL")
+      str=$(p6_string_append "$str" "$prefix$item" "$P6_NL")
     fi
   done
   str=$(p6_string_append "$str" "$sts" " ")


### PR DESCRIPTION
## What
Two small fixes in `p6df::modules::aws::prompt::context`:
1. Remove unnecessary double-quoting around command substitution for `prefix`
2. Remove the extra space between `$prefix` and `$item` in the string append call (prefix already has trailing padding)

## Why
The double-quoted command substitution `"$(…)"` is redundant for a local variable assignment. The extra space after `$prefix` caused double-spacing in the prompt output since `p6_string_space_pad` already pads to 16 chars.

## Test plan
- Reviewed diff manually
- Prompt context output will now align correctly without double-space

## Dependencies
None