### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::aws::deps()
-#
-#>
-######################################################################
 p6df::modules::aws::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-docker
@@ -22,58 +16,33 @@ p6df::modules::aws::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::aws::vscodes()
-#
-#>
-######################################################################
-p6df::modules::aws::vscodes() {
+p6df::modules::aws::path::init() {
 
-  p6df::modules::vscode::extension::install AmazonWebServices.aws-toolkit-vscode
-  p6df::modules::vscode::extension::install kddejong.vscode-cfn-lint
-  p6df::modules::vscode::extension::install loganarnett.lambda-snippets
+  local _module="$1"
+  local _dir="$2"
+  p6_path_if "$P6_DFZ_SRC_DIR/aws/aws-codebuild-docker-images/local_builds"
+  p6_path_if "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-aws/libexec"
 
   p6_return_void
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::aws::vscodes::config()
-#
-#>
-######################################################################
-p6df::modules::aws::vscodes::config() {
+p6df::modules::aws::home::symlinks() {
 
- cat <<'EOF'
-  "aws.telemetry": false,
-  "cfnLint.runOnSave": true,
-  "yaml.schemas": {
-    "https://raw.githubusercontent.com/awslabs/goformation/master/schema/cloudformation.schema.json": [
-      "cloudformation*.yml",
-      "cloudformation*.yaml",
-      "**/*cfn*.yml",
-      "**/*cfn*.yaml"
-    ],
-    "https://raw.githubusercontent.com/aws/serverless-application-model/main/samtranslator/schema/schema.json": [
-      "template.yml",
-      "template.yaml",
-      "**/*sam*.yml",
-      "**/*sam*.yaml"
-    ]
-  }
-EOF
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-aws/share/.aws" "$HOME/.aws"
+
+  p6_file_symlink "$P6_DFZ_SRC_DIR/zxkane/aws-skills/.claude/skills/aws-agentic-ai"                         "$HOME/.claude/skills/aws-agentic-ai"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/zxkane/aws-skills/.claude/skills/aws-cdk-development"                    "$HOME/.claude/skills/aws-cdk-development"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/zxkane/aws-skills/.claude/skills/aws-cost-operations"                    "$HOME/.claude/skills/aws-cost-operations"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/zxkane/aws-skills/.claude/skills/aws-mcp-setup"                          "$HOME/.claude/skills/aws-mcp-setup"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/zxkane/aws-skills/.claude/skills/aws-serverless-eda"                     "$HOME/.claude/skills/aws-serverless-eda"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/ahmedasmar/devops-claude-skills/aws-cost-optimization"                   "$HOME/.claude/skills/aws-cost-optimization"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/hashicorp/agent-skills/packer/builders/skills/aws-ami-builder"           "$HOME/.claude/skills/aws-ami-builder"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/hashicorp/agent-skills/packer/hcp/skills/push-to-registry"               "$HOME/.claude/skills/push-to-registry"
 
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::aws::external::brews()
-#
-#>
 ######################################################################
 p6df::modules::aws::external::brews() {
 
@@ -116,6 +85,118 @@ p6df::modules::aws::external::brews() {
   p6_return_void
 }
 
+######################################################################
+p6df::modules::aws::langs() {
+
+  # languages
+  p6df::modules::aws::langs::js
+  p6df::modules::aws::langs::python
+  p6df::modules::aws::langs::go
+  p6df::modules::aws::langs::ruby
+  p6df::modules::aws::langs::rust
+
+  # codebuild local
+  docker pull amazon/aws-codebuild-local:latest --disable-content-trust=false
+
+  # eks kubectl client
+  p6_network_file_download "https://s3.us-west-2.amazonaws.com/amazon-eks/1.34.2/2025-11-13/bin/darwin/amd64/kubectl" "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-aws/libexec/aws-eks-kubectl"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::aws::mcp() {
+
+  p6_js_npm_global_install "@imazhar101/mcp-aws-server"
+
+  p6df::modules::anthropic::mcp::server::add "aws" "npx" "-y" "@imazhar101/mcp-aws-server"
+  p6df::modules::openai::mcp::server::add "aws" "npx" "-y" "@imazhar101/mcp-aws-server"
+
+  p6_return_void
+}
+######################################################################
+p6df::modules::aws::vscodes() {
+
+  p6df::modules::vscode::extension::install AmazonWebServices.aws-toolkit-vscode
+  p6df::modules::vscode::extension::install kddejong.vscode-cfn-lint
+  p6df::modules::vscode::extension::install loganarnett.lambda-snippets
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::aws::vscodes::config() {
+
+ cat <<'EOF'
+  "aws.telemetry": false,
+  "cfnLint.runOnSave": true,
+  "yaml.schemas": {
+    "https://raw.githubusercontent.com/awslabs/goformation/master/schema/cloudformation.schema.json": [
+      "cloudformation*.yml",
+      "cloudformation*.yaml",
+      "**/*cfn*.yml",
+      "**/*cfn*.yaml"
+    ],
+    "https://raw.githubusercontent.com/aws/serverless-application-model/main/samtranslator/schema/schema.json": [
+      "template.yml",
+      "template.yaml",
+      "**/*sam*.yml",
+      "**/*sam*.yaml"
+    ]
+  }
+EOF
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::aws::profile::on() {
+  local profile="$1"
+  local code="$2"
+
+  p6_run_code "$code"
+
+  p6_aws_cli_organization_on "$P6_AWS_ORG"
+#  p6df::modules::aws::profiles::list
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::aws::profile::off() {
+  local code="$1"
+
+  p6_env_unset_from_code "$code"
+
+  p6_aws_cli_organization_off
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::aws::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::aws::vscodes()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::aws::vscodes::config()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::aws::external::brews()
+#
+#>
 ######################################################################
 #<
 #
@@ -230,25 +311,6 @@ p6df::modules::aws::langs::clones() {
 #  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
-p6df::modules::aws::langs() {
-
-  # languages
-  p6df::modules::aws::langs::js
-  p6df::modules::aws::langs::python
-  p6df::modules::aws::langs::go
-  p6df::modules::aws::langs::ruby
-  p6df::modules::aws::langs::rust
-
-  # codebuild local
-  docker pull amazon/aws-codebuild-local:latest --disable-content-trust=false
-
-  # eks kubectl client
-  p6_network_file_download "https://s3.us-west-2.amazonaws.com/amazon-eks/1.34.2/2025-11-13/bin/darwin/amd64/kubectl" "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-aws/libexec/aws-eks-kubectl"
-
-  p6_return_void
-}
-
-######################################################################
 #<
 #
 # Function: p6df::modules::aws::home::symlinks()
@@ -256,40 +318,12 @@ p6df::modules::aws::langs() {
 #  Environment:	 HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
-p6df::modules::aws::home::symlinks() {
-
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-aws/share/.aws" "$HOME/.aws"
-
-  p6_file_symlink "$P6_DFZ_SRC_DIR/zxkane/aws-skills/.claude/skills/aws-agentic-ai"                         "$HOME/.claude/skills/aws-agentic-ai"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/zxkane/aws-skills/.claude/skills/aws-cdk-development"                    "$HOME/.claude/skills/aws-cdk-development"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/zxkane/aws-skills/.claude/skills/aws-cost-operations"                    "$HOME/.claude/skills/aws-cost-operations"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/zxkane/aws-skills/.claude/skills/aws-mcp-setup"                          "$HOME/.claude/skills/aws-mcp-setup"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/zxkane/aws-skills/.claude/skills/aws-serverless-eda"                     "$HOME/.claude/skills/aws-serverless-eda"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/ahmedasmar/devops-claude-skills/aws-cost-optimization"                   "$HOME/.claude/skills/aws-cost-optimization"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/hashicorp/agent-skills/packer/builders/skills/aws-ami-builder"           "$HOME/.claude/skills/aws-ami-builder"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/hashicorp/agent-skills/packer/hcp/skills/push-to-registry"               "$HOME/.claude/skills/push-to-registry"
-
-  p6_return_void
-}
-
-######################################################################
 #<
 #
 # Function: p6df::modules::aws::path::init()
 #
 #  Environment:	 P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
-######################################################################
-p6df::modules::aws::path::init() {
-
-  local _module="$1"
-  local _dir="$2"
-  p6_path_if "$P6_DFZ_SRC_DIR/aws/aws-codebuild-docker-images/local_builds"
-  p6_path_if "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-aws/libexec"
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #
@@ -352,19 +386,6 @@ p6df::modules::aws::prompt::context() {
 #  Environment:	 P6_AWS_ORG
 #>
 ######################################################################
-p6df::modules::aws::profile::on() {
-  local profile="$1"
-  local code="$2"
-
-  p6_run_code "$code"
-
-  p6_aws_cli_organization_on "$P6_AWS_ORG"
-#  p6df::modules::aws::profiles::list
-
-  p6_return_void
-}
-
-######################################################################
 #<
 #
 # Function: p6df::modules::aws::profile::off(code)
@@ -374,29 +395,8 @@ p6df::modules::aws::profile::on() {
 #
 #>
 ######################################################################
-p6df::modules::aws::profile::off() {
-  local code="$1"
-
-  p6_env_unset_from_code "$code"
-
-  p6_aws_cli_organization_off
-
-  p6_return_void
-}
-
-######################################################################
 #<
 #
 # Function: p6df::modules::aws::mcp()
 #
 #>
-######################################################################
-p6df::modules::aws::mcp() {
-
-  p6_js_npm_global_install "@imazhar101/mcp-aws-server"
-
-  p6df::modules::anthropic::mcp::server::add "aws" "npx" "-y" "@imazhar101/mcp-aws-server"
-  p6df::modules::openai::mcp::server::add "aws" "npx" "-y" "@imazhar101/mcp-aws-server"
-
-  p6_return_void
-}

--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::aws::deps()
+#
+#>
+######################################################################
 p6df::modules::aws::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-docker
@@ -16,6 +22,13 @@ p6df::modules::aws::deps() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::aws::path::init()
+#
+#  Environment:	 P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
 p6df::modules::aws::path::init() {
 
   local _module="$1"
@@ -26,6 +39,13 @@ p6df::modules::aws::path::init() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::aws::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
 ######################################################################
 p6df::modules::aws::home::symlinks() {
 
@@ -43,6 +63,12 @@ p6df::modules::aws::home::symlinks() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::aws::external::brews()
+#
+#>
 ######################################################################
 p6df::modules::aws::external::brews() {
 
@@ -86,6 +112,13 @@ p6df::modules::aws::external::brews() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::aws::langs()
+#
+#  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
 p6df::modules::aws::langs() {
 
   # languages
@@ -105,6 +138,12 @@ p6df::modules::aws::langs() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::aws::mcp()
+#
+#>
+######################################################################
 p6df::modules::aws::mcp() {
 
   p6_js_npm_global_install "@imazhar101/mcp-aws-server"
@@ -115,6 +154,12 @@ p6df::modules::aws::mcp() {
   p6_return_void
 }
 ######################################################################
+#<
+#
+# Function: p6df::modules::aws::vscodes()
+#
+#>
+######################################################################
 p6df::modules::aws::vscodes() {
 
   p6df::modules::vscode::extension::install AmazonWebServices.aws-toolkit-vscode
@@ -124,6 +169,12 @@ p6df::modules::aws::vscodes() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::aws::vscodes::config()
+#
+#>
 ######################################################################
 p6df::modules::aws::vscodes::config() {
 
@@ -150,6 +201,17 @@ EOF
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::aws::profile::on(profile, code)
+#
+#  Args:
+#	profile -
+#	code -
+#
+#  Environment:	 P6_AWS_ORG
+#>
+######################################################################
 p6df::modules::aws::profile::on() {
   local profile="$1"
   local code="$2"
@@ -163,6 +225,15 @@ p6df::modules::aws::profile::on() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::aws::profile::off(code)
+#
+#  Args:
+#	code -
+#
+#>
+######################################################################
 p6df::modules::aws::profile::off() {
   local code="$1"
 
@@ -173,30 +244,6 @@ p6df::modules::aws::profile::off() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::aws::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::aws::vscodes()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::aws::vscodes::config()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::aws::external::brews()
-#
-#>
 ######################################################################
 #<
 #
@@ -306,27 +353,6 @@ p6df::modules::aws::langs::clones() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::aws::langs()
-#
-#  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::aws::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::aws::path::init()
-#
-#  Environment:	 P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-#<
-#
 # Function: stream  = p6df::modules::aws::profiles::list()
 #
 #  Returns:
@@ -374,29 +400,3 @@ p6df::modules::aws::prompt::context() {
   p6_return_str "$str"
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::aws::profile::on(profile, code)
-#
-#  Args:
-#	profile -
-#	code -
-#
-#  Environment:	 P6_AWS_ORG
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::aws::profile::off(code)
-#
-#  Args:
-#	code -
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::aws::mcp()
-#
-#>


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None